### PR TITLE
Scale back schema validation

### DIFF
--- a/confluent-kafka/topic/main.tf
+++ b/confluent-kafka/topic/main.tf
@@ -122,13 +122,6 @@ resource "confluent_schema" "schema" {
 
     ## AVRO schema content validation
     precondition {
-      // Check that the schema file contains the key 'namespace' if it is an AVRO schema
-      condition = (!local.schema_is_url || local.schema_ignored || var.schema.format != "AVRO") ? true : (
-        contains(keys(local.schema_content_json), "namespace")
-      )
-      error_message = "Schema must be a valid AVRO schema. Must contain key 'namespace'"
-    }
-    precondition {
       // Check that the schema file contains the key 'name' if it is an AVRO schema
       condition = (!local.schema_is_url || local.schema_ignored || var.schema.format != "AVRO") ? true : (
         contains(keys(local.schema_content_json), "name")
@@ -163,13 +156,6 @@ resource "confluent_schema" "schema" {
         contains(keys(local.schema_content_json), "$schema")
       )
       error_message = "Schema must be a valid JSON schema. Must contain key '$schema'"
-    }
-    precondition {
-      // Check that the schema file contains the key '$id' if it is an JSON schema
-      condition = (!local.schema_is_url || local.schema_ignored || var.schema.format != "JSON") ? true : (
-        contains(keys(local.schema_content_json), "$id")
-      )
-      error_message = "Schema must be a valid JSON schema. Must contain key '$id'"
     }
     precondition {
       // Check that the schema file contains the key 'title' if it is an JSON schema

--- a/confluent-kafka/topic/variables.tf
+++ b/confluent-kafka/topic/variables.tf
@@ -235,16 +235,6 @@ variable "schema" {
 
   ## AVRO schema file content validation
   validation {
-    // Check that the schema file contains the key 'namespace' if it is an AVRO schema
-    condition = (var.schema.path == null || !can(file(var.schema.path))) ? true : (
-      var.schema.path == null ||
-      var.schema.format == null ||
-      var.schema.format != "AVRO" ||
-      contains(keys(jsondecode(file(var.schema.path))), "namespace")
-    )
-    error_message = "Schema must be a valid AVRO schema. Must contain key 'namespace'"
-  }
-  validation {
     // Check that the schema file contains the key 'name' if it is an AVRO schema
     condition = (var.schema.path == null || !can(file(var.schema.path))) ? true : (
       var.schema.path == null ||
@@ -295,16 +285,6 @@ variable "schema" {
       contains(keys(jsondecode(file(var.schema.path))), "$schema")
     )
     error_message = "Schema must be a valid JSON schema. Must contain key '$schema'."
-  }
-  validation {
-    // Check that the schema file contains the key '$id' if it is a JSON schema
-    condition = (var.schema.path == null || !can(file(var.schema.path))) ? true : (
-      var.schema.path == null ||
-      var.schema.format == null ||
-      var.schema.format != "JSON" ||
-      contains(keys(jsondecode(file(var.schema.path))), "$id")
-    )
-    error_message = "Schema must be a valid JSON schema. Must contain key '$id'"
   }
   validation {
     // Check that the schema file contains the key 'title' if it is a JSON schema


### PR DESCRIPTION
Removes '$id' (JSON) and 'namespace' (AVRO) schema requirements.

We can also consider removing the field 'title' from JSON schemas, however the field 'name' is required for AVRO and it is nice to have parity between JSON and AVRO.